### PR TITLE
Distributed training example script

### DIFF
--- a/examples/train_gsm8k+aqua-distributed-lora.py
+++ b/examples/train_gsm8k+aqua-distributed-lora.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import argparse
+
+import datasets
+import numpy as np
+import transformers
+from datasets import concatenate_datasets
+from transformers import EarlyStoppingCallback
+
+import gadgets
+import wandb
+
+# IMHO this makes it even messier than before, but keeping it here for now
+
+# os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+# for i in range(torch.cuda.device_count()):
+#     print(i, torch.cuda.get_device_properties(i))
+
+# global arguments:
+
+# (1) general
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument("--output_dir", type=str)
+argparser.add_argument("--model_name", type=str, default="google/flan-t5-large")
+argparser.add_argument("--wandb_project_name", type=str)
+argparser.add_argument("--wandb_tags", type=str, default="calculator,gsm8k,aqua,supervised",
+                       help="Coma-separater list of given wandb tags")
+argparser.add_argument("--local_rank", type=int, default=-1)
+
+# (2) script-specific
+argparser.add_argument("--finetune_whole_model", type=str, default="True")
+# note that turning this to False will cause the training to fail on FSDP:
+# ValueError: `FlatParameter` requires uniform `requires_grad`
+
+argparser.add_argument("--lora_hidden_states_ratio", type=int, default=16)
+
+args = argparser.parse_args()
+args.finetune_whole_model = args.finetune_whole_model == "True"
+
+# PART: model init
+gadget_model_cls = gadgets.model.gadget_assisted_model(transformers.T5ForConditionalGeneration)
+
+model = gadget_model_cls.from_pretrained(args.model_name)  # no device_map
+tokenizer = transformers.T5Tokenizer.from_pretrained(args.model_name)
+
+# PART: update model for unknown tokens
+gadgets.utils.add_new_token(
+    "<",
+    is_special=False,
+    tokenizer=tokenizer,
+    model=model,
+    init_with=["[", ">"],
+)
+
+text = "<gadget>2+2</gadget>"
+encoded = tokenizer(text, return_tensors="pt").input_ids
+decoded = tokenizer.batch_decode(encoded, skip_special_tokens=True, spaces_between_special_tokens=False)
+assert decoded[0] == text, decoded[0]
+
+# PART: update generate() to support gadgets
+model.prepare_for_generate(
+    tokenizer,
+    enabled_gadgets=[gadgets.gadget.Calculator()],
+    default_max_tokens=512,
+)
+data_collator = transformers.DataCollatorForSeq2Seq(tokenizer, model=model)
+
+preprocess = gadgets.prep.Preprocessing(tokenizer=tokenizer)
+
+
+# PART: datasets curation
+def parse_and_preprocess_aqua(example: dict[str, str]):
+    example_with_gadgets = gadgets.aqua.parse(example)
+    input_sample = preprocess(example_with_gadgets)
+    return input_sample
+
+
+def parse_and_preprocess_gsm(example: dict[str, str]):
+    example = gadgets.gsm8k.parse(example)
+    example = preprocess(example)
+    return example
+
+
+aqua = datasets.load_dataset("aqua_rat", split="train").map(parse_and_preprocess_aqua)
+aqua_val = datasets.load_dataset("aqua_rat", split="validation").map(parse_and_preprocess_aqua).select(range(100))
+
+gsm8k = datasets.load_dataset("gsm8k", "main").map(parse_and_preprocess_gsm)
+
+train_valid_ds = gsm8k["train"].train_test_split(test_size=100, seed=42)
+
+# upscaling GSM - we don't do that now
+# gsm_idx = list(range(len(train_valid_ds["train"])))
+# train_valid_ds["train"] = train_valid_ds["train"].select(random.choice(gsm_idx) for _ in range(len(aqua)))
+
+train_ds = concatenate_datasets([train_valid_ds["train"], aqua])
+train_ds = train_ds.shuffle()
+
+valid_ds = train_valid_ds["test"]
+tests_ds = gsm8k["test"]
+
+# PART: shuffling of the logged predictions
+random_rng = np.random.default_rng(42)
+log_predictions_indices = random_rng.choice(
+    range(len(valid_ds)),
+    size=min(64, min(len(valid_ds), len(aqua_val))),
+    replace=False,
+)
+
+# PART: custom evaluations' logging
+metrics = gadgets.metrics.MyMetrics(
+    tokenizer=tokenizer,
+    log_predictions=True,
+    log_predictions_indices=log_predictions_indices,
+    datasets_id_length={"gsm": len(valid_ds), "aqua": len(aqua_val)}  # TODO: ordering and sizes must match eval_dataset
+)
+
+# PART: partial model finetuning
+if not args.finetune_whole_model:
+    from gadgets.lora_utils import patch_linears_with_lora
+    import loralib
+
+    patch_linears_with_lora(model, r=args.lora_hidden_states_ratio)
+
+    model.train()
+    loralib.mark_only_lora_as_trainable(model)
+
+wandb.init(
+        project="gadgets",
+        tags=[args.model_name] + args.wandb_tags.split(","),
+        group=args.wandb_tags.replace(",", "-"),
+        dir=args.output_dir,
+        config={"model_name": args.model_name,
+                "finetune_whole_model": args.finetune_whole_model,
+                "params_trained_percent": args.lora_hidden_states_ratio}
+    )
+
+# PART: training configuration
+training_args = transformers.Seq2SeqTrainingArguments(
+    output_dir=args.output_dir,
+    local_rank=args.local_rank,
+    # distributed GPU training params:
+    # shard optimizer + gradients + model params, shard automatically by the class name:
+    fsdp="full_shard auto_wrap",
+    # sharded class names:
+    fsdp_config={"fsdp_transformer_layer_cls_to_wrap": ["T5Block"]},
+    learning_rate=2e-5,
+    do_train=True,
+    do_eval=True,
+    warmup_steps=5000,
+    max_steps=50_000,
+    per_device_train_batch_size=1,
+    gradient_accumulation_steps=10,
+    per_device_eval_batch_size=1,
+    eval_accumulation_steps=16,
+    logging_steps=100,
+    eval_steps=2000,
+    save_steps=2000,
+    evaluation_strategy="steps",
+    bf16=True,
+    predict_with_generate=True,
+    generation_max_length=512,
+    include_inputs_for_metrics=True,
+    # report_to="wandb",
+    metric_for_best_model="aqua_correct_results",
+    greater_is_better=True,
+    load_best_model_at_end=True,
+    save_total_limit=1,
+    # no place_model_on_device=True
+)
+
+trainer = transformers.Seq2SeqTrainer(
+    model=model,
+    args=training_args,
+    train_dataset=train_ds,
+    eval_dataset=concatenate_datasets([valid_ds, aqua_val]),
+    tokenizer=tokenizer,
+    data_collator=data_collator,
+    compute_metrics=metrics,
+    callbacks=[EarlyStoppingCallback(early_stopping_patience=15)]
+)
+
+trainer.train()
+trainer.evaluate(eval_dataset=tests_ds, metric_key_prefix="test")

--- a/examples/train_gsm8k+aqua-distributed.py
+++ b/examples/train_gsm8k+aqua-distributed.py
@@ -29,13 +29,14 @@ argparser.add_argument("--wandb_tags", type=str, default="calculator,gsm8k,aqua,
 argparser.add_argument("--local_rank", type=int, default=-1)
 
 # (2) script-specific
-argparser.add_argument("--finetune_whole_model", type=bool, default=True)  
+argparser.add_argument("--finetune_whole_model", type=str, default="True")
 # note that turning this to False will cause the training to fail on FSDP:
 # ValueError: `FlatParameter` requires uniform `requires_grad`
 
 argparser.add_argument("--finetune_percent", type=int, default=10, choices=[10, 20, 30, 40])
 
 args = argparser.parse_args()
+args.finetune_whole_model = args.finetune_whole_model == "True"
 
 # PART: model init
 gadget_model_cls = gadgets.model.gadget_assisted_model(transformers.T5ForConditionalGeneration)

--- a/examples/train_gsm8k+aqua-distributed.py
+++ b/examples/train_gsm8k+aqua-distributed.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
 import argparse
-import os
-import random
 
 import datasets
 import numpy as np
 import transformers
-import wandb
 from datasets import concatenate_datasets
 from transformers import EarlyStoppingCallback
 
 import gadgets
+import wandb
 
 # IMHO this makes it even messier than before, but keeping it here for now
 
@@ -28,9 +26,13 @@ argparser.add_argument("--model_name", type=str, default="google/flan-t5-large")
 argparser.add_argument("--wandb_project_name", type=str)
 argparser.add_argument("--wandb_tags", type=str, default="calculator,gsm8k,aqua,supervised",
                        help="Coma-separater list of given wandb tags")
+argparser.add_argument("--local_rank", type=int, default=-1)
 
 # (2) script-specific
-argparser.add_argument("--finetune_whole_model", type=bool, default=False)
+argparser.add_argument("--finetune_whole_model", type=bool, default=True)  
+# note that turning this to False will cause the training to fail on FSDP:
+# ValueError: `FlatParameter` requires uniform `requires_grad`
+
 argparser.add_argument("--finetune_percent", type=int, default=10, choices=[10, 20, 30, 40])
 
 args = argparser.parse_args()
@@ -38,7 +40,7 @@ args = argparser.parse_args()
 # PART: model init
 gadget_model_cls = gadgets.model.gadget_assisted_model(transformers.T5ForConditionalGeneration)
 
-model = gadget_model_cls.from_pretrained(args.model_name, device_map="auto")
+model = gadget_model_cls.from_pretrained(args.model_name)  # no device_map
 tokenizer = transformers.T5Tokenizer.from_pretrained(args.model_name)
 
 # PART: update model for unknown tokens
@@ -80,11 +82,11 @@ def parse_and_preprocess_gsm(example: dict[str, str]):
 
 
 aqua = datasets.load_dataset("aqua_rat", split="train").map(parse_and_preprocess_aqua)
-aqua_val = datasets.load_dataset("aqua_rat", split="validation").map(parse_and_preprocess_aqua)
+aqua_val = datasets.load_dataset("aqua_rat", split="validation").map(parse_and_preprocess_aqua).select(range(100))
 
 gsm8k = datasets.load_dataset("gsm8k", "main").map(parse_and_preprocess_gsm)
 
-train_valid_ds = gsm8k["train"].train_test_split(test_size=400, seed=42)
+train_valid_ds = gsm8k["train"].train_test_split(test_size=100, seed=42)
 
 # upscaling GSM - we don't do that now
 # gsm_idx = list(range(len(train_valid_ds["train"])))
@@ -177,29 +179,36 @@ else:
 
 # PART: training configuration
 training_args = transformers.Seq2SeqTrainingArguments(
-    output_dir=os.path.join(args.output_dir, wandb.run.name),
-    learning_rate=5e-5,
+    output_dir=args.output_dir,
+    local_rank=args.local_rank,
+    # distributed GPU training params:
+    # shard optimizer + gradients + model params, shard automatically by the class name:
+    fsdp="full_shard auto_wrap",
+    # sharded class names:
+    fsdp_config={"fsdp_transformer_layer_cls_to_wrap": ["T5Block"]},
+    learning_rate=2e-5,
     do_train=True,
     do_eval=True,
-    warmup_steps=1000,
-    max_steps=1_000_000,
-    per_device_train_batch_size=32,
-    gradient_accumulation_steps=1,
+    warmup_steps=5000,
+    max_steps=50_000,
+    per_device_train_batch_size=1,
+    gradient_accumulation_steps=10,
     per_device_eval_batch_size=1,
     eval_accumulation_steps=16,
-    logging_steps=50,
-    eval_steps=4000,
-    save_steps=4000,
+    logging_steps=100,
+    eval_steps=2000,
+    save_steps=2000,
     evaluation_strategy="steps",
     bf16=True,
     predict_with_generate=True,
     generation_max_length=512,
     include_inputs_for_metrics=True,
-    report_to="wandb",
-    metric_for_best_model="correct_results",
+    # report_to="wandb",
+    metric_for_best_model="aqua_correct_results",
     greater_is_better=True,
     load_best_model_at_end=True,
-    save_total_limit=3,
+    save_total_limit=1,
+    # no place_model_on_device=True
 )
 
 trainer = transformers.Seq2SeqTrainer(

--- a/examples/train_gsm8k+aqua-slice.py
+++ b/examples/train_gsm8k+aqua-slice.py
@@ -80,11 +80,11 @@ def parse_and_preprocess_gsm(example: dict[str, str]):
 
 
 aqua = datasets.load_dataset("aqua_rat", split="train").map(parse_and_preprocess_aqua)
-aqua_val = datasets.load_dataset("aqua_rat", split="validation").map(parse_and_preprocess_aqua)
+aqua_val = datasets.load_dataset("aqua_rat", split="validation").map(parse_and_preprocess_aqua).select(range(100))
 
 gsm8k = datasets.load_dataset("gsm8k", "main").map(parse_and_preprocess_gsm)
 
-train_valid_ds = gsm8k["train"].train_test_split(test_size=400, seed=42)
+train_valid_ds = gsm8k["train"].train_test_split(test_size=100, seed=42)
 
 # upscaling GSM - we don't do that now
 # gsm_idx = list(range(len(train_valid_ds["train"])))
@@ -181,22 +181,22 @@ training_args = transformers.Seq2SeqTrainingArguments(
     learning_rate=5e-5,
     do_train=True,
     do_eval=True,
-    warmup_steps=1000,
-    max_steps=1_000_000,
-    per_device_train_batch_size=32,
-    gradient_accumulation_steps=1,
+    warmup_steps=5000,
+    max_steps=50_000,
+    per_device_train_batch_size=1,
+    gradient_accumulation_steps=10,
     per_device_eval_batch_size=1,
     eval_accumulation_steps=16,
-    logging_steps=50,
-    eval_steps=4000,
-    save_steps=4000,
+    logging_steps=100,
+    eval_steps=2000,
+    save_steps=2000,
     evaluation_strategy="steps",
     bf16=True,
     predict_with_generate=True,
     generation_max_length=512,
     include_inputs_for_metrics=True,
     report_to="wandb",
-    metric_for_best_model="correct_results",
+    metric_for_best_model="aqua_correct_results",
     greater_is_better=True,
     load_best_model_at_end=True,
     save_total_limit=3,

--- a/gadgets/lora_utils.py
+++ b/gadgets/lora_utils.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, NamedTuple
+
+import loralib
+import torch
+
+
+class ModuleInfo(NamedTuple):
+    attr: str
+    path: str
+    module: torch.nn.Module
+    parent: torch.nn.Module
+
+
+def all_module_parent_pairs(model: torch.nn.Module) -> Iterable[ModuleInfo]:
+    for path, module in model.named_modules():
+        if path == "":
+            assert module is model
+            yield ModuleInfo("", "", model, parent=None)
+            continue
+
+        *parent_path, attr = path.split(".")
+        parent = model
+        for child in parent_path:
+            parent = getattr(parent, child)
+        yield ModuleInfo(attr, path, module, parent)
+
+
+def patch_linears_with_lora(
+        model: torch.nn.Module,
+        only_if_name_contains: Iterable[str] | None = ("attn.k_proj", "attn.q_proj", "attn.v_proj"),
+        **lora_kwargs: Any,
+):
+    modules = list(all_module_parent_pairs(model))
+    if only_if_name_contains is not None:
+        only_if_name_contains = set(only_if_name_contains)
+
+    was_training = model.training
+
+    for module_info in modules:
+        module = module_info.module
+
+        if isinstance(module, loralib.LoRALayer):
+            continue
+        if not isinstance(module, torch.nn.Linear):
+            continue
+        if only_if_name_contains is not None:
+            if not any(string in module_info.path for string in only_if_name_contains):
+                continue
+
+        was_module_training = module.training
+        replacement = loralib.Linear(
+            module.in_features,
+            module.out_features,
+            bias=module.bias is not None,
+            merge_weights=True,
+            **lora_kwargs
+        )
+        replacement = replacement.to(module.weight.device)
+        replacement.eval()
+
+        with torch.no_grad():
+            replacement.weight[:] = module.weight
+            if module.bias is not None:
+                replacement.bias[:] = module.bias
+
+            test_input = torch.rand(2, module.in_features).to(module.weight.device)
+            assert torch.allclose(module(test_input), replacement(test_input))
+
+        if was_module_training:
+            replacement.train()
+
+        setattr(module_info.parent, module_info.attr, replacement)
+        modules = list(all_module_parent_pairs(model))
+
+    if was_training:
+        model.train()


### PR DESCRIPTION
This PR adds an example script for distributed training using [Fully Sharded Data Parallel (FSDP)](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html) paradigm with AQuA+GSM datasets.

Note that this technique seems to collide with slice tuning: fine-tuning a subset of parameters causes the training to fail on FSDP's 
```
`ValueError: `FlatParameter` requires uniform `requires_grad` 
```

@markcheeky If possible, we should fix this in the slice tuning support.