### PR TITLE
Gadget Assist wrapped for Decoder-Only models and Inference script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data/mawps/
 data/svamp/
 data/asdiv/
 predictions/
+*env

--- a/gadgets/gadget_assisted_model.py
+++ b/gadgets/gadget_assisted_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Optional, Callable, List
+from typing import Callable, List, Optional
 
 import bs4
 import torch
@@ -53,6 +53,7 @@ class GadgetAssistedModel:
                  prefix_allowed_tokens_fn: Optional[Callable[[int, torch.Tensor], List[int]]] = None,
                  synced_gpus: Optional[bool] = None,
                  streamer: Optional["BaseStreamer"] = None,
+                 architecture: Optional[str] = 'encoder-decoder', # Could pass 'decoder-only
                  **kwargs,
                  # signature of GenerationMixin.generate() in Transformers==4.28.1, with inputs<=>input_ids
                  ) -> torch.LongTensor:
@@ -69,6 +70,11 @@ class GadgetAssistedModel:
             full_output: Full structured output of the model, including gadget, output, and result tags.
             result: Final result of the model, or None if not found.
         """
+
+        if architecture not in ['encoder-decoder', 'decoder-only']: # Supported styles
+            raise Exception('Unsupported architecture type for Gadget model')
+        
+        self.architecture_style = architecture
 
         stopping_criteria = transformers.generation.StoppingCriteriaList([StopAfterGadgetCall(self.tokenizer)])
 
@@ -127,11 +133,17 @@ class GadgetAssistedModel:
             ], dim=-1)
 
             model_output: transformers.utils.ModelOutput
-            model_output = super().generate(input_ids=input_ids,
-                                            stopping_criteria=stopping_criteria,
-                                            decoder_input_ids=decoder_input_ids,
-                                            **kwargs)[0]  # TODO This does not work in batch mode
-            # which occurs in evaluation during training
+
+            if self.architecture_style == 'encoder-decoder':
+                model_output = super().generate(input_ids=input_ids,
+                                                stopping_criteria=stopping_criteria,
+                                                decoder_input_ids=decoder_input_ids,
+                                                **kwargs)[0]  # TODO This does not work in batch mode
+                # which occurs in evaluation during training
+            elif self.architecture_style == 'decoder-only':
+                model_output = super().generate(input_ids=input_ids,
+                                                stopping_criteria=stopping_criteria
+                                                **kwargs)[0]
 
             # model.generate() outputs starts with decoder_input_ids
             total_output_str = self.tokenizer.decode(model_output,

--- a/gadgets/gadget_assisted_model.py
+++ b/gadgets/gadget_assisted_model.py
@@ -127,14 +127,14 @@ class GadgetAssistedModel:
             if min_tokens is not None:
                 kwargs["min_new_tokens"] = max(0, min_tokens - num_total_tokens)
 
-            decoder_input_ids = torch.cat([
-                torch.tensor(self.config.decoder_start_token_id, dtype=torch.long).to(self.device).reshape(1, 1),
-                total_output_encoded
-            ], dim=-1)
-
             model_output: transformers.utils.ModelOutput
 
             if self.architecture_style == 'encoder-decoder':
+                decoder_input_ids = torch.cat([
+                  torch.tensor(self.config.decoder_start_token_id, dtype=torch.long).to(self.device).reshape(1, 1),
+                  total_output_encoded
+                ], dim=-1)
+                
                 model_output = super().generate(input_ids=input_ids,
                                                 stopping_criteria=stopping_criteria,
                                                 decoder_input_ids=decoder_input_ids,
@@ -143,7 +143,7 @@ class GadgetAssistedModel:
             elif self.architecture_style == 'decoder-only':
                 model_output = super().generate(input_ids=input_ids,
                                                 stopping_criteria=stopping_criteria
-                                                **kwargs)[0]
+                                              )[0]
 
             # model.generate() outputs starts with decoder_input_ids
             total_output_str = self.tokenizer.decode(model_output,

--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,69 @@
+from argparse import ArgumentParser
+
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    LlamaModelForCausalLM,
+    LlamaTokenizer,
+    T5ForConditionalGeneration,
+    T5Tokenizer,
+)
+
+from gadgets.gadget import Calculator
+from gadgets.gadget_assisted_model import GadgetAssistedModel
+
+parser = ArgumentParser()
+parser.add_argument('model_type', default='encoder-decoder') # Can also be decoder-only
+args = parser.parse_args()
+
+
+class GadgetAssistedT5(GadgetAssistedModel, T5ForConditionalGeneration):
+    # GadgetAssistedModel overrides the standard generate() from transformers
+    pass
+
+class GadgetAssistedLlama(GadgetAssistedModel, LlamaModelForCausalLM):
+    # GadgetAssistedModel overrides the standard generate() from transformers
+    pass
+
+
+t5_model_id = "MU-NLPC/calcformer-t5-large"
+llama_model_id = 'meta-llama/Llama-2-7b-chat-hf'
+bloke_model_id = 'TheBloke/Llama-2-7B-Chat-GPTQ'
+
+if args.model_type == 'encoder-decoder':
+    model = GadgetAssistedT5.from_pretrained(t5_model_id)
+    tokenizer = T5Tokenizer.from_pretrained(t5_model_id)
+
+# TODO Use .env for local
+from google.colab import userdata
+
+hf_auth = userdata.get('hf_auth')
+
+if args.model_type == 'decoder-only':
+    model = GadgetAssistedLlama.from_pretrained(llama_model_id,
+                                                device_map="auto",
+                                                torch_dtype="auto",
+                                                use_auth_token=hf_auth
+                                                )
+
+    tokenizer = LlamaTokenizer.from_pretrained(llama_model_id, 
+                                               use_auth_token=hf_auth
+                                               )
+
+
+model.prepare_for_generate(tokenizer,
+                           enabled_gadgets=[Calculator()],
+                           default_max_tokens=512)
+
+query = """
+    The profit from a business transaction is shared among 2 business partners,
+    Mike and Johnson in the ratio 2:5 respectively.
+    If Johnson got $2500, how much will Mike have
+    after spending some of his share on a shirt that costs $200?
+"""
+
+inputs = tokenizer(query, return_tensors="pt")
+output_ids = model.generate(**inputs, architecture=args.model_type)
+# output_ids
+output_str = tokenizer.decode(output_ids[0], spaces_between_special_tokens=False)
+print(output_str)

--- a/inference.py
+++ b/inference.py
@@ -1,9 +1,11 @@
+import os
 from argparse import ArgumentParser
 
+from dotenv import load_dotenv
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
-    LlamaModelForCausalLM,
+    LlamaForCausalLM,
     LlamaTokenizer,
     T5ForConditionalGeneration,
     T5Tokenizer,
@@ -11,6 +13,9 @@ from transformers import (
 
 from gadgets.gadget import Calculator
 from gadgets.gadget_assisted_model import GadgetAssistedModel
+
+# Load environment variables and secret keys
+load_dotenv('env')
 
 parser = ArgumentParser()
 parser.add_argument('model_type', default='encoder-decoder') # Can also be decoder-only
@@ -21,7 +26,7 @@ class GadgetAssistedT5(GadgetAssistedModel, T5ForConditionalGeneration):
     # GadgetAssistedModel overrides the standard generate() from transformers
     pass
 
-class GadgetAssistedLlama(GadgetAssistedModel, LlamaModelForCausalLM):
+class GadgetAssistedLlama(GadgetAssistedModel, LlamaForCausalLM):
     # GadgetAssistedModel overrides the standard generate() from transformers
     pass
 
@@ -34,10 +39,7 @@ if args.model_type == 'encoder-decoder':
     model = GadgetAssistedT5.from_pretrained(t5_model_id)
     tokenizer = T5Tokenizer.from_pretrained(t5_model_id)
 
-# TODO Use .env for local
-from google.colab import userdata
-
-hf_auth = userdata.get('hf_auth')
+hf_auth = os.getenv('HF_AUTH')
 
 if args.model_type == 'decoder-only':
     model = GadgetAssistedLlama.from_pretrained(llama_model_id,


### PR DESCRIPTION
Add support for Decoder Only models like GPT-2 and LLama2 to be wrapped by GadgetAssistedModel and override the `.generate` function

Gotchas:
- Decoder only models do not need the `decoder_input_ids`, hence move them into encoder-decoder block 
- Removed `**kwargs**` from the generate call for decoder only due to the error documented in 77e3bea (TypeError: unsupported operand type(s) for ** or pow(): 'StoppingCriteriaList' and 'dict'). This would have to be patched up to support passing of kwargs. 

Inference script 
- Inference as per the README.md with examples for wrapping Llama2 in addition to T5